### PR TITLE
Fix default port for MCP server

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,5 +137,5 @@ def index():
     return jsonify({"message": "Advice MCP is live!"})
 
 if __name__ == '__main__':
-    port = int(os.environ.get("PORT", 5000))
+    port = int(os.environ.get("PORT", 8000))
     app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- expose port 8000 by default

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f617ee6688332a3f0c43ef7b8e4b3